### PR TITLE
Implement issue #6 content regeneration endpoints

### DIFF
--- a/client/src/components/content/GenerateContentGrid.tsx
+++ b/client/src/components/content/GenerateContentGrid.tsx
@@ -88,19 +88,11 @@ const GenerateContentGrid = ({ videoId }: GenerateContentGridProps) => {
     }
   ];
   
-  // This is a mock mutation since the endpoints to regenerate content don't exist yet
-  // In a real implementation, we would use the actual endpoints
+  // Mutation to call backend endpoints for content generation
   const generateContentMutation = useMutation({
     mutationFn: async (option: ContentOption) => {
-      // In a real implementation, we would call apiRequest here
-      // await apiRequest("POST", option.path);
-      
-      // For now, we'll simulate a delay
-      return new Promise((resolve) => {
-        setTimeout(() => {
-          resolve({ success: true });
-        }, 2000);
-      });
+      const response = await apiRequest("POST", option.path);
+      return await response.json();
     },
     onMutate: (option) => {
       setPendingContent(option.id);

--- a/server/rateLimiter.ts
+++ b/server/rateLimiter.ts
@@ -1,0 +1,33 @@
+const RATE_LIMIT = 10;
+const WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
+interface RateInfo {
+  count: number;
+  windowStart: number;
+}
+
+const userLimits = new Map<string, RateInfo>();
+
+export function consume(userId: string): boolean {
+  const now = Date.now();
+  const info = userLimits.get(userId);
+  if (!info || now - info.windowStart > WINDOW_MS) {
+    userLimits.set(userId, { count: 1, windowStart: now });
+    return true;
+  }
+
+  if (info.count >= RATE_LIMIT) {
+    return false;
+  }
+
+  info.count++;
+  return true;
+}
+
+export function getRemaining(userId: string): number {
+  const info = userLimits.get(userId);
+  if (!info || Date.now() - info.windowStart > WINDOW_MS) {
+    return RATE_LIMIT;
+  }
+  return Math.max(0, RATE_LIMIT - info.count);
+}


### PR DESCRIPTION
## Summary
- add in-memory rate limiter
- implement `/api/videos/:id/generate-*` endpoints
- call these new endpoints from `GenerateContentGrid`

## Testing
- `npm install`
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68689bd4d2348332b64011b8650eed00