### PR TITLE
Add user and video management endpoints

### DIFF
--- a/server/routers/index.ts
+++ b/server/routers/index.ts
@@ -5,6 +5,7 @@ import videosRouter from './videos.router';
 import reportsRouter from './reports.router';
 import flashcardsRouter from './flashcards.router';
 import ideasRouter from './ideas.router';
+import usersRouter from './users.router';
 import devRouter from './dev.router';
 import { setupAuth } from '../replitAuth';
 import { errorHandler } from './middleware';
@@ -19,6 +20,7 @@ export async function registerAppRoutes(app: Express): Promise<Server> {
   app.use('/api/reports', reportsRouter);
   app.use('/api/flashcard-sets', flashcardsRouter);
   app.use('/api/idea-sets', ideasRouter);
+  app.use('/api/users', usersRouter);
   app.use('/api/dev', devRouter);
 
   // Apply global error handling middleware

--- a/server/routers/users.router.ts
+++ b/server/routers/users.router.ts
@@ -1,0 +1,52 @@
+import { Router } from 'express';
+import { isAuthenticated } from '../replitAuth';
+import { storage } from '../storage';
+
+const router = Router();
+
+// Get user profile
+router.get('/:id', isAuthenticated, async (req: any, res) => {
+  try {
+    if (req.params.id !== req.user.claims.sub) {
+      return res.status(403).json({ message: 'Unauthorized' });
+    }
+    const user = await storage.getUser(req.params.id);
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    res.json(user);
+  } catch (error) {
+    console.error('Error fetching user profile:', error);
+    res.status(500).json({ message: 'Failed to fetch user' });
+  }
+});
+
+// Update user profile
+router.put('/:id', isAuthenticated, async (req: any, res) => {
+  try {
+    if (req.params.id !== req.user.claims.sub) {
+      return res.status(403).json({ message: 'Unauthorized' });
+    }
+    const updated = await storage.upsertUser({ id: req.params.id, ...req.body });
+    res.json(updated);
+  } catch (error) {
+    console.error('Error updating user profile:', error);
+    res.status(500).json({ message: 'Failed to update user' });
+  }
+});
+
+// Delete user profile
+router.delete('/:id', isAuthenticated, async (req: any, res) => {
+  try {
+    if (req.params.id !== req.user.claims.sub) {
+      return res.status(403).json({ message: 'Unauthorized' });
+    }
+    await storage.deleteUser(req.params.id);
+    res.json({ message: 'User deleted' });
+  } catch (error) {
+    console.error('Error deleting user:', error);
+    res.status(500).json({ message: 'Failed to delete user' });
+  }
+});
+
+export default router;

--- a/server/routers/videos.router.ts
+++ b/server/routers/videos.router.ts
@@ -596,4 +596,42 @@ router.post('/:id/reprocess', isAuthenticated, async (req: any, res) => {
   }
 });
 
+// Update video metadata
+router.put('/:id', isAuthenticated, async (req: any, res) => {
+  try {
+    const videoId = parseInt(req.params.id, 10);
+    const video = await storage.getVideo(videoId);
+    if (!video) {
+      return res.status(404).json({ message: 'Video not found' });
+    }
+    if (video.userId !== req.user.claims.sub) {
+      return res.status(403).json({ message: 'Unauthorized' });
+    }
+    const updated = await storage.updateVideo(videoId, req.body);
+    res.json(updated);
+  } catch (error) {
+    console.error('Error updating video:', error);
+    res.status(500).json({ message: 'Failed to update video' });
+  }
+});
+
+// Delete video and all related data
+router.delete('/:id', isAuthenticated, async (req: any, res) => {
+  try {
+    const videoId = parseInt(req.params.id, 10);
+    const video = await storage.getVideo(videoId);
+    if (!video) {
+      return res.status(404).json({ message: 'Video not found' });
+    }
+    if (video.userId !== req.user.claims.sub) {
+      return res.status(403).json({ message: 'Unauthorized' });
+    }
+    await storage.deleteVideo(videoId);
+    res.json({ message: 'Video deleted' });
+  } catch (error) {
+    console.error('Error deleting video:', error);
+    res.status(500).json({ message: 'Failed to delete video' });
+  }
+});
+
 export default router;


### PR DESCRIPTION
## Summary
- add new router for user profile CRUD operations
- extend router registration to include users
- add update and delete endpoints in videos router
- add storage helpers for cascading delete of videos/users

## Testing
- `npm run check` *(fails: TS errors in unrelated parts)*

------
https://chatgpt.com/codex/tasks/task_e_68689bdafec08332803bb00cc098895f