### PR TITLE
Implement placeholder pages and fix navigation

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,13 +6,29 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import NotFound from "@/pages/not-found";
 import Dashboard from "@/pages/dashboard";
 import VideoDetail from "@/pages/video-detail";
+import VideosPage from "@/pages/videos";
+import ReportsPage from "@/pages/reports";
+import ReportDetailPage from "@/pages/reports/[id]";
+import FlashcardsPage from "@/pages/flashcards";
+import FlashcardSetPage from "@/pages/flashcards/[setId]";
+import FlashcardStudyPage from "@/pages/flashcards/[setId]/study";
+import IdeasPage from "@/pages/ideas";
+import IdeaSetPage from "@/pages/ideas/[setId]";
 import AppLayout from "@/components/layout/AppLayout";
 
 function Router() {
   return (
     <Switch>
       <Route path="/" component={Dashboard} />
+      <Route path="/videos" component={VideosPage} />
       <Route path="/videos/:id" component={VideoDetail} />
+      <Route path="/reports" component={ReportsPage} />
+      <Route path="/reports/:id" component={ReportDetailPage} />
+      <Route path="/flashcards" component={FlashcardsPage} />
+      <Route path="/flashcards/:setId" component={FlashcardSetPage} />
+      <Route path="/flashcards/:setId/study" component={FlashcardStudyPage} />
+      <Route path="/ideas" component={IdeasPage} />
+      <Route path="/ideas/:setId" component={IdeaSetPage} />
       {/* Fallback to 404 */}
       <Route component={NotFound} />
     </Switch>

--- a/client/src/components/common/BulkActions.tsx
+++ b/client/src/components/common/BulkActions.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+interface BulkActionsProps {
+  children?: React.ReactNode;
+}
+
+const BulkActions = ({ children }: BulkActionsProps) => {
+  return (
+    <div className="flex items-center space-x-2 mb-4">
+      {children || <span className="text-sm text-gray-500">Select items to see actions</span>}
+    </div>
+  );
+};
+
+export default BulkActions;

--- a/client/src/components/common/ContentCard.tsx
+++ b/client/src/components/common/ContentCard.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+interface ContentCardProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+const ContentCard = ({ children, className = "" }: ContentCardProps) => {
+  return (
+    <div className={`bg-white rounded-lg shadow-md border border-gray-200 p-4 ${className}`}>
+      {children}
+    </div>
+  );
+};
+
+export default ContentCard;

--- a/client/src/components/common/EmptyState.tsx
+++ b/client/src/components/common/EmptyState.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+interface EmptyStateProps {
+  icon?: string;
+  message: string;
+}
+
+const EmptyState = ({ icon = "info", message }: EmptyStateProps) => {
+  return (
+    <div className="text-center py-10">
+      <span className="material-icons text-4xl text-gray-300 mb-2">{icon}</span>
+      <p className="text-gray-500">{message}</p>
+    </div>
+  );
+};
+
+export default EmptyState;

--- a/client/src/components/common/ExportModal.tsx
+++ b/client/src/components/common/ExportModal.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+interface ExportModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const ExportModal = ({ open, onClose }: ExportModalProps) => {
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Export Options</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-gray-600">Export functionality coming soon.</p>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ExportModal;

--- a/client/src/components/common/SearchAndFilter.tsx
+++ b/client/src/components/common/SearchAndFilter.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { Input } from "@/components/ui/input";
+
+interface SearchAndFilterProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+const SearchAndFilter = ({ value, onChange, placeholder }: SearchAndFilterProps) => {
+  return (
+    <div className="mb-4">
+      <Input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder || "Search"}
+      />
+    </div>
+  );
+};
+
+export default SearchAndFilter;

--- a/client/src/components/layout/AppLayout.tsx
+++ b/client/src/components/layout/AppLayout.tsx
@@ -13,7 +13,7 @@ interface AppLayoutProps {
 const AppLayout = ({ children }: AppLayoutProps) => {
   const { user, isLoading, isAuthenticated } = useAuth();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-  const [, navigate] = useLocation();
+  const [location, navigate] = useLocation();
 
   const toggleMobileMenu = () => {
     setIsMobileMenuOpen(!isMobileMenuOpen);
@@ -83,21 +83,25 @@ const AppLayout = ({ children }: AppLayoutProps) => {
 
         {/* Mobile Bottom Navigation */}
         <nav className="md:hidden bg-white border-t border-gray-200 flex justify-around items-center py-3 px-4">
-          <a href="/" className="flex flex-col items-center text-primary">
+          <a href="/" className={`flex flex-col items-center ${location === '/' ? 'text-primary' : 'text-gray-500'}`}> 
             <span className="material-icons text-lg">dashboard</span>
             <span className="text-xs mt-1">Dashboard</span>
           </a>
-          <a href="#" className="flex flex-col items-center text-gray-500">
+          <a href="/videos" className={`flex flex-col items-center ${location.startsWith('/videos') ? 'text-primary' : 'text-gray-500'}`}> 
             <span className="material-icons text-lg">video_library</span>
             <span className="text-xs mt-1">Videos</span>
           </a>
-          <a href="#" className="flex flex-col items-center text-gray-500">
+          <a href="/reports" className={`flex flex-col items-center ${location.startsWith('/reports') ? 'text-primary' : 'text-gray-500'}`}> 
             <span className="material-icons text-lg">description</span>
             <span className="text-xs mt-1">Reports</span>
           </a>
-          <a href="#" className="flex flex-col items-center text-gray-500">
+          <a href="/flashcards" className={`flex flex-col items-center ${location.startsWith('/flashcards') ? 'text-primary' : 'text-gray-500'}`}> 
             <span className="material-icons text-lg">style</span>
             <span className="text-xs mt-1">Flashcards</span>
+          </a>
+          <a href="/ideas" className={`flex flex-col items-center ${location.startsWith('/ideas') ? 'text-primary' : 'text-gray-500'}`}> 
+            <span className="material-icons text-lg">lightbulb</span>
+            <span className="text-xs mt-1">Ideas</span>
           </a>
         </nav>
       </div>

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -34,13 +34,13 @@ const Sidebar = ({ user }: SidebarProps) => {
             key={item.path}
             href={item.path}
             className={`flex items-center px-3 py-2 text-sm font-medium rounded-md ${
-              location === item.path
+              location.startsWith(item.path)
                 ? "bg-primary-50 text-primary-700"
                 : "text-gray-700 hover:bg-gray-50"
             }`}
           >
             <span className={`material-icons mr-3 ${
-              location === item.path ? "text-primary-500" : "text-gray-400"
+              location.startsWith(item.path) ? "text-primary-500" : "text-gray-400"
             }`}>
               {item.icon}
             </span>

--- a/client/src/pages/flashcards/[setId]/index.tsx
+++ b/client/src/pages/flashcards/[setId]/index.tsx
@@ -1,0 +1,31 @@
+import { useParams } from "wouter";
+import { useQuery } from "@tanstack/react-query";
+import { FlashcardSet } from "@shared/schema";
+import EmptyState from "@/components/common/EmptyState";
+import ContentCard from "@/components/common/ContentCard";
+
+const FlashcardSetPage = () => {
+  const { setId } = useParams<{ setId: string }>();
+  const { data: set, isLoading } = useQuery<FlashcardSet | null>({
+    queryKey: ["/api/flashcard-sets/" + setId],
+  });
+
+  if (isLoading) return <p className="p-4">Loading...</p>;
+  if (!set) return <EmptyState icon="style" message="Set not found" />;
+
+  return (
+    <main className="flex-1 overflow-y-auto p-4 md:p-6 bg-gray-50">
+      <div className="max-w-3xl mx-auto space-y-4">
+        <h1 className="text-2xl font-semibold text-gray-900">{set.title}</h1>
+        <ContentCard>
+          <p className="text-gray-700 mb-4">{set.description}</p>
+          <a href={`/flashcards/${setId}/study`} className="text-primary-500">
+            Start Study Mode
+          </a>
+        </ContentCard>
+      </div>
+    </main>
+  );
+};
+
+export default FlashcardSetPage;

--- a/client/src/pages/flashcards/[setId]/study.tsx
+++ b/client/src/pages/flashcards/[setId]/study.tsx
@@ -1,0 +1,18 @@
+import { useParams } from "wouter";
+import EmptyState from "@/components/common/EmptyState";
+
+const FlashcardStudyPage = () => {
+  const { setId } = useParams<{ setId: string }>();
+
+  // Study mode not implemented yet
+  return (
+    <main className="flex-1 overflow-y-auto p-4 md:p-6 bg-gray-50">
+      <div className="max-w-xl mx-auto">
+        <h1 className="text-2xl font-semibold text-gray-900 mb-4">Study Mode</h1>
+        <EmptyState icon="style" message={`Study mode for set ${setId} coming soon`} />
+      </div>
+    </main>
+  );
+};
+
+export default FlashcardStudyPage;

--- a/client/src/pages/flashcards/index.tsx
+++ b/client/src/pages/flashcards/index.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import FlashcardSetCard from "@/components/content/FlashcardSetCard";
+import SearchAndFilter from "@/components/common/SearchAndFilter";
+import EmptyState from "@/components/common/EmptyState";
+import { FlashcardSet } from "@shared/schema";
+
+const FlashcardsPage = () => {
+  const [search, setSearch] = useState("");
+  const { data: sets, isLoading } = useQuery<FlashcardSet[]>({
+    queryKey: ["/api/flashcard-sets"],
+  });
+
+  const filtered = sets?.filter((s) =>
+    s.title.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <main className="flex-1 overflow-y-auto p-4 md:p-6 bg-gray-50">
+      <div className="max-w-6xl mx-auto">
+        <h1 className="text-2xl font-semibold text-gray-900 mb-4">My Flashcards</h1>
+        <SearchAndFilter value={search} onChange={setSearch} placeholder="Search flashcards" />
+        {isLoading ? (
+          <p>Loading...</p>
+        ) : filtered && filtered.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {filtered.map((set) => (
+              <FlashcardSetCard key={set.id} flashcardSet={set} />
+            ))}
+          </div>
+        ) : (
+          <EmptyState icon="style" message="No flashcard sets found" />
+        )}
+      </div>
+    </main>
+  );
+};
+
+export default FlashcardsPage;

--- a/client/src/pages/ideas/[setId].tsx
+++ b/client/src/pages/ideas/[setId].tsx
@@ -1,0 +1,26 @@
+import { useParams } from "wouter";
+import { useQuery } from "@tanstack/react-query";
+import IdeaList from "@/components/content/IdeaList";
+import EmptyState from "@/components/common/EmptyState";
+import { IdeaSet } from "@shared/schema";
+
+const IdeaSetPage = () => {
+  const { setId } = useParams<{ setId: string }>();
+  const { data: set, isLoading } = useQuery<IdeaSet | null>({
+    queryKey: ["/api/idea-sets/" + setId],
+  });
+
+  if (isLoading) return <p className="p-4">Loading...</p>;
+  if (!set) return <EmptyState icon="lightbulb" message="Idea set not found" />;
+
+  return (
+    <main className="flex-1 overflow-y-auto p-4 md:p-6 bg-gray-50">
+      <div className="max-w-3xl mx-auto space-y-4">
+        <h1 className="text-2xl font-semibold text-gray-900">{set.title}</h1>
+        <IdeaList title={set.title} ideaSetId={set.id} date={new Date(set.createdAt)} />
+      </div>
+    </main>
+  );
+};
+
+export default IdeaSetPage;

--- a/client/src/pages/ideas/index.tsx
+++ b/client/src/pages/ideas/index.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import IdeaList from "@/components/content/IdeaList";
+import SearchAndFilter from "@/components/common/SearchAndFilter";
+import EmptyState from "@/components/common/EmptyState";
+import { IdeaSet } from "@shared/schema";
+
+const IdeasPage = () => {
+  const [search, setSearch] = useState("");
+  const { data: sets, isLoading } = useQuery<IdeaSet[]>({
+    queryKey: ["/api/idea-sets"],
+  });
+
+  const filtered = sets?.filter((s) =>
+    s.title.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <main className="flex-1 overflow-y-auto p-4 md:p-6 bg-gray-50">
+      <div className="max-w-6xl mx-auto space-y-4">
+        <h1 className="text-2xl font-semibold text-gray-900">Ideas Hub</h1>
+        <SearchAndFilter value={search} onChange={setSearch} placeholder="Search ideas" />
+        {isLoading ? (
+          <p>Loading...</p>
+        ) : filtered && filtered.length > 0 ? (
+          filtered.map((set) => (
+            <IdeaList
+              key={set.id}
+              title={set.title}
+              ideaSetId={set.id}
+              date={new Date(set.createdAt)}
+            />
+          ))
+        ) : (
+          <EmptyState icon="lightbulb" message="No ideas found" />
+        )}
+      </div>
+    </main>
+  );
+};
+
+export default IdeasPage;

--- a/client/src/pages/reports/[id].tsx
+++ b/client/src/pages/reports/[id].tsx
@@ -1,0 +1,28 @@
+import { useParams } from "wouter";
+import { useQuery } from "@tanstack/react-query";
+import { Report } from "@shared/schema";
+import ContentCard from "@/components/common/ContentCard";
+import EmptyState from "@/components/common/EmptyState";
+
+const ReportDetailPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const { data: report, isLoading } = useQuery<Report | null>({
+    queryKey: ["/api/reports/" + id],
+  });
+
+  if (isLoading) return <p className="p-4">Loading...</p>;
+  if (!report) return <EmptyState icon="description" message="Report not found" />;
+
+  return (
+    <main className="flex-1 overflow-y-auto p-4 md:p-6 bg-gray-50">
+      <div className="max-w-3xl mx-auto space-y-4">
+        <h1 className="text-2xl font-semibold text-gray-900">{report.title}</h1>
+        <ContentCard>
+          <pre className="whitespace-pre-wrap text-sm text-gray-800">{report.content}</pre>
+        </ContentCard>
+      </div>
+    </main>
+  );
+};
+
+export default ReportDetailPage;

--- a/client/src/pages/reports/index.tsx
+++ b/client/src/pages/reports/index.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import ReportCard from "@/components/content/ReportCard";
+import SearchAndFilter from "@/components/common/SearchAndFilter";
+import EmptyState from "@/components/common/EmptyState";
+import { Report } from "@shared/schema";
+
+const ReportsPage = () => {
+  const [search, setSearch] = useState("");
+  const { data: reports, isLoading } = useQuery<Report[]>({
+    queryKey: ["/api/reports"],
+  });
+
+  const filtered = reports?.filter((r) =>
+    r.title.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <main className="flex-1 overflow-y-auto p-4 md:p-6 bg-gray-50">
+      <div className="max-w-6xl mx-auto">
+        <h1 className="text-2xl font-semibold text-gray-900 mb-4">My Reports</h1>
+        <SearchAndFilter value={search} onChange={setSearch} placeholder="Search reports" />
+        {isLoading ? (
+          <p>Loading...</p>
+        ) : filtered && filtered.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {filtered.map((report) => (
+              <ReportCard key={report.id} report={report} />
+            ))}
+          </div>
+        ) : (
+          <EmptyState icon="description" message="No reports found" />
+        )}
+      </div>
+    </main>
+  );
+};
+
+export default ReportsPage;

--- a/client/src/pages/videos/index.tsx
+++ b/client/src/pages/videos/index.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import VideoCard from "@/components/video/VideoCard";
+import SearchAndFilter from "@/components/common/SearchAndFilter";
+import EmptyState from "@/components/common/EmptyState";
+import { Video } from "@shared/schema";
+
+const VideosPage = () => {
+  const [search, setSearch] = useState("");
+
+  const { data: videos, isLoading } = useQuery<Video[]>({
+    queryKey: ["/api/videos"],
+  });
+
+  const filtered = videos?.filter((v) =>
+    v.title.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <main className="flex-1 overflow-y-auto p-4 md:p-6 bg-gray-50">
+      <div className="max-w-6xl mx-auto">
+        <h1 className="text-2xl font-semibold text-gray-900 mb-4">My Videos</h1>
+        <SearchAndFilter value={search} onChange={setSearch} placeholder="Search videos" />
+        {isLoading ? (
+          <p>Loading...</p>
+        ) : filtered && filtered.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {filtered.map((video) => (
+              <VideoCard key={video.id} video={video} />
+            ))}
+          </div>
+        ) : (
+          <EmptyState icon="videocam_off" message="No videos found" />
+        )}
+      </div>
+    </main>
+  );
+};
+
+export default VideosPage;


### PR DESCRIPTION
## Summary
- add placeholder content management pages
- add shared common components
- update routing and navigation links

## Testing
- `npm run check` *(fails: many type errors present)*

------
https://chatgpt.com/codex/tasks/task_e_68689be0c32c83329cbde1e98b11c0b2