### PR TITLE
Implement basic report editing

### DIFF
--- a/client/src/components/content/ReportCard.tsx
+++ b/client/src/components/content/ReportCard.tsx
@@ -8,10 +8,12 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
+import ReportEditor from "@/components/content/ReportEditor";
 
 interface ReportCardProps {
   report: {
     id: number;
+    videoId: number;
     title: string;
     content: string;
     type: string;
@@ -104,10 +106,12 @@ const ReportCard = ({ report }: ReportCardProps) => {
                   <span className="material-icons text-sm mr-2">content_copy</span>
                   Copy
                 </DropdownMenuItem>
-                <DropdownMenuItem>
-                  <span className="material-icons text-sm mr-2">edit</span>
-                  Edit
-                </DropdownMenuItem>
+                <ReportEditor report={report}>
+                  <DropdownMenuItem>
+                    <span className="material-icons text-sm mr-2">edit</span>
+                    Edit
+                  </DropdownMenuItem>
+                </ReportEditor>
                 <DropdownMenuItem>
                   <span className="material-icons text-sm mr-2">file_download</span>
                   Download

--- a/client/src/components/content/ReportEditor.tsx
+++ b/client/src/components/content/ReportEditor.tsx
@@ -1,0 +1,82 @@
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/queryClient";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/hooks/use-toast";
+import { useState } from "react";
+
+interface ReportEditorProps {
+  report: {
+    id: number;
+    videoId: number;
+    title: string;
+    content: string;
+  };
+  children: React.ReactNode;
+}
+
+const schema = z.object({
+  title: z.string().min(1, "Title is required"),
+  content: z.string().min(1, "Content is required"),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+const ReportEditor = ({ report, children }: ReportEditorProps) => {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+
+  const { register, handleSubmit, formState: { errors }, reset } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { title: report.title, content: report.content },
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (data: FormValues) => {
+      await apiRequest("PUT", `/api/reports/${report.id}`, data);
+    },
+    onSuccess: () => {
+      toast({ title: "Report updated" });
+      setOpen(false);
+      queryClient.invalidateQueries({ queryKey: ["/api/reports"] });
+      queryClient.invalidateQueries({ queryKey: [`/api/videos/${report.videoId}/reports`] });
+    },
+    onError: (err: any) => {
+      toast({ title: "Failed to update report", description: err.message, variant: "destructive" });
+    }
+  });
+
+  const onSubmit = (data: FormValues) => {
+    mutation.mutate(data);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { setOpen(o); if (!o) reset({ title: report.title, content: report.content }); }}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="sm:max-w-xl">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <DialogHeader>
+            <DialogTitle>Edit Report</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Input placeholder="Title" {...register("title")}/>
+            {errors.title && <p className="text-sm text-red-500">{errors.title.message}</p>}
+            <Textarea rows={10} {...register("content")}/>
+            {errors.content && <p className="text-sm text-red-500">{errors.content.message}</p>}
+          </div>
+          <DialogFooter>
+            <Button type="submit" disabled={mutation.isPending}>Save</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ReportEditor;

--- a/client/src/components/video-detail/ReportsTab.tsx
+++ b/client/src/components/video-detail/ReportsTab.tsx
@@ -1,0 +1,39 @@
+import ReportCard from "@/components/content/ReportCard";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useQuery } from "@tanstack/react-query";
+import { getQueryFn } from "@/lib/queryClient";
+
+interface ReportsTabProps {
+  videoId: number;
+}
+
+const ReportsTab = ({ videoId }: ReportsTabProps) => {
+  const { data: reports, isLoading } = useQuery({
+    queryKey: [`/api/videos/${videoId}/reports`],
+    enabled: !!videoId,
+  });
+
+  return (
+    <div className="max-w-6xl mx-auto p-4 space-y-4">
+      {isLoading ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {Array(2)
+            .fill(0)
+            .map((_, i) => (
+              <Skeleton key={i} className="h-40" />
+            ))}
+        </div>
+      ) : reports && reports.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {reports.map((r: any) => (
+            <ReportCard key={r.id} report={r} />
+          ))}
+        </div>
+      ) : (
+        <p className="text-center py-10 text-gray-500">No reports available.</p>
+      )}
+    </div>
+  );
+};
+
+export default ReportsTab;

--- a/client/src/pages/video-detail.tsx
+++ b/client/src/pages/video-detail.tsx
@@ -9,6 +9,7 @@ import { formatDistanceToNow } from "date-fns";
 import { Button } from "@/components/ui/button";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
+import ReportsTab from "@/components/video-detail/ReportsTab";
 
 const VideoDetailPage = () => {
   const [, params] = useRoute("/videos/:id");
@@ -137,11 +138,7 @@ const VideoDetailPage = () => {
           <TranscriptView videoId={videoId || 0} transcript="" />
         );
       case "reports":
-        return (
-          <div className="max-w-6xl mx-auto p-4">
-            <p className="text-center py-10 text-gray-500">Reports view will be implemented soon.</p>
-          </div>
-        );
+        return <ReportsTab videoId={videoId || 0} />;
       case "flashcards":
         return (
           <div className="max-w-6xl mx-auto p-4">

--- a/server/routers/reports.router.ts
+++ b/server/routers/reports.router.ts
@@ -30,4 +30,20 @@ router.delete('/:id', isAuthenticated, async (req: any, res) => {
   }
 });
 
+// Update report
+router.put('/:id', isAuthenticated, async (req: any, res) => {
+  try {
+    const reportId = parseInt(req.params.id, 10);
+    const { title, content } = req.body;
+    const updated = await storage.updateReport(reportId, { title, content });
+    if (!updated) {
+      return res.status(404).json({ message: 'Report not found' });
+    }
+    res.json(updated);
+  } catch (error) {
+    console.error('Error updating report:', error);
+    res.status(500).json({ message: 'Failed to update report' });
+  }
+});
+
 export default router;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -47,6 +47,7 @@ export interface IStorage {
   createReport(report: InsertReport): Promise<Report>;
   getVideoReports(videoId: number): Promise<Report[]>;
   getUserReports(userId: string, limit?: number): Promise<Report[]>;
+  updateReport(id: number, data: Partial<InsertReport>): Promise<Report | null>;
   deleteReport(id: number): Promise<void>;
   
   // Flashcard operations
@@ -182,7 +183,22 @@ export class DatabaseStorage implements IStorage {
       .orderBy(desc(reports.createdAt))
       .limit(limit);
   }
-  
+
+  async updateReport(
+    id: number,
+    data: Partial<InsertReport>
+  ): Promise<Report | null> {
+    const [updated] = await db
+      .update(reports)
+      .set({
+        ...data,
+        videoId: undefined,
+      })
+      .where(eq(reports.id, id))
+      .returning();
+    return updated || null;
+  }
+
   async deleteReport(id: number): Promise<void> {
     await db.delete(reports).where(eq(reports.id, id));
   }


### PR DESCRIPTION
## Summary
- add updateReport method to storage and router
- create ReportEditor component
- display reports in new ReportsTab component
- integrate reports tab into video detail page
- enable editing of reports via ReportEditor

## Testing
- `npm run check` *(fails: cannot find type definition file for 'node')*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68689be6d4488332aa1777d7a1fecad1