### PR TITLE
Implement basic content export features

### DIFF
--- a/client/src/components/content/FlashcardSetCard.tsx
+++ b/client/src/components/content/FlashcardSetCard.tsx
@@ -16,6 +16,7 @@ interface FlashcardSetCardProps {
     description?: string;
     createdAt: string;
     videoTitle?: string;
+    videoId?: number;
     cardCount?: number;
   };
 }
@@ -50,6 +51,30 @@ const FlashcardSetCard = ({ flashcardSet }: FlashcardSetCardProps) => {
       deleteFlashcardSetMutation.mutate(flashcardSet.id);
     }
   };
+
+  const handleDownload = async () => {
+    try {
+      const res = await apiRequest(
+        "GET",
+        `/api/flashcard-sets/${flashcardSet.id}/export?format=csv`
+      );
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `${flashcardSet.title.replace(/\s+/g, "_")}.csv`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      toast({
+        title: "Error",
+        description: "Failed to download flashcards",
+        variant: "destructive",
+      });
+    }
+  };
   
   return (
     <div className="bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 overflow-hidden border border-gray-200">
@@ -80,7 +105,7 @@ const FlashcardSetCard = ({ flashcardSet }: FlashcardSetCardProps) => {
                   <span className="material-icons text-sm mr-2">edit</span>
                   Edit
                 </DropdownMenuItem>
-                <DropdownMenuItem>
+                <DropdownMenuItem onClick={handleDownload}>
                   <span className="material-icons text-sm mr-2">file_download</span>
                   Download
                 </DropdownMenuItem>

--- a/client/src/components/content/ReportCard.tsx
+++ b/client/src/components/content/ReportCard.tsx
@@ -68,6 +68,30 @@ const ReportCard = ({ report }: ReportCardProps) => {
       }
     );
   };
+
+  const handleDownload = async () => {
+    try {
+      const res = await apiRequest(
+        "GET",
+        `/api/reports/${report.id}/export?format=markdown`
+      );
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `${report.title.replace(/\s+/g, "_")}.md`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      toast({
+        title: "Error",
+        description: "Failed to download report",
+        variant: "destructive",
+      });
+    }
+  };
   
   return (
     <div className="bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 overflow-hidden border border-gray-200">
@@ -108,7 +132,7 @@ const ReportCard = ({ report }: ReportCardProps) => {
                   <span className="material-icons text-sm mr-2">edit</span>
                   Edit
                 </DropdownMenuItem>
-                <DropdownMenuItem>
+                <DropdownMenuItem onClick={handleDownload}>
                   <span className="material-icons text-sm mr-2">file_download</span>
                   Download
                 </DropdownMenuItem>

--- a/server/routers/flashcards.router.ts
+++ b/server/routers/flashcards.router.ts
@@ -30,6 +30,31 @@ router.get('/:id/cards', isAuthenticated, async (req: any, res) => {
   }
 });
 
+// Export flashcard set
+router.get('/:id/export', isAuthenticated, async (req: any, res) => {
+  try {
+    const setId = parseInt(req.params.id, 10);
+    const format = (req.query.format as string) || 'csv';
+    if (format !== 'csv') {
+      return res.status(400).json({ message: 'Unsupported format' });
+    }
+    const set = await storage.getFlashcardSet(setId);
+    if (!set) {
+      return res.status(404).json({ message: 'Flashcard set not found' });
+    }
+    const cards = await storage.getFlashcards(setId);
+    const escape = (text: string) => `"${text.replace(/"/g, '""')}"`;
+    const csv = ['Question,Answer', ...cards.map(c => `${escape(c.question)},${escape(c.answer)}`)].join('\n');
+    const filename = `${set.title.replace(/\s+/g, '_')}.csv`;
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.send(csv);
+  } catch (error) {
+    console.error('Error exporting flashcard set:', error);
+    res.status(500).json({ message: 'Failed to export flashcard set' });
+  }
+});
+
 // Delete flashcard set
 router.delete('/:id', isAuthenticated, async (req: any, res) => {
   try {

--- a/server/routers/reports.router.ts
+++ b/server/routers/reports.router.ts
@@ -18,6 +18,28 @@ router.get('/', isAuthenticated, async (req: any, res) => {
   }
 });
 
+// Export report
+router.get('/:id/export', isAuthenticated, async (req: any, res) => {
+  try {
+    const reportId = parseInt(req.params.id, 10);
+    const format = (req.query.format as string) || 'markdown';
+    if (format !== 'markdown') {
+      return res.status(400).json({ message: 'Unsupported format' });
+    }
+    const report = await storage.getReport(reportId);
+    if (!report) {
+      return res.status(404).json({ message: 'Report not found' });
+    }
+    const filename = `report-${reportId}.md`;
+    res.setHeader('Content-Type', 'text/markdown');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.send(`# ${report.title}\n\n${report.content}`);
+  } catch (error) {
+    console.error('Error exporting report:', error);
+    res.status(500).json({ message: 'Failed to export report' });
+  }
+});
+
 // Delete report
 router.delete('/:id', isAuthenticated, async (req: any, res) => {
   try {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -42,9 +42,10 @@ export interface IStorage {
   // Summary operations
   createSummary(summary: InsertSummary): Promise<Summary>;
   getVideoSummary(videoId: number): Promise<Summary | undefined>;
-  
+
   // Report operations
   createReport(report: InsertReport): Promise<Report>;
+  getReport(id: number): Promise<Report | undefined>;
   getVideoReports(videoId: number): Promise<Report[]>;
   getUserReports(userId: string, limit?: number): Promise<Report[]>;
   deleteReport(id: number): Promise<void>;
@@ -54,6 +55,7 @@ export interface IStorage {
   createFlashcard(card: InsertFlashcard): Promise<Flashcard>;
   getFlashcardSets(videoId: number): Promise<FlashcardSet[]>;
   getUserFlashcardSets(userId: string, limit?: number): Promise<FlashcardSet[]>;
+  getFlashcardSet(id: number): Promise<FlashcardSet | undefined>;
   getFlashcards(setId: number): Promise<Flashcard[]>;
   deleteFlashcardSet(id: number): Promise<void>;
   
@@ -156,6 +158,11 @@ export class DatabaseStorage implements IStorage {
     const [createdReport] = await db.insert(reports).values(report).returning();
     return createdReport;
   }
+
+  async getReport(id: number): Promise<Report | undefined> {
+    const [report] = await db.select().from(reports).where(eq(reports.id, id));
+    return report;
+  }
   
   async getVideoReports(videoId: number): Promise<Report[]> {
     return db
@@ -239,7 +246,12 @@ export class DatabaseStorage implements IStorage {
     
     return setsWithCounts;
   }
-  
+
+  async getFlashcardSet(id: number): Promise<FlashcardSet | undefined> {
+    const [set] = await db.select().from(flashcardSets).where(eq(flashcardSets.id, id));
+    return set;
+  }
+
   async getFlashcards(setId: number): Promise<Flashcard[]> {
     return db
       .select()


### PR DESCRIPTION
## Summary
- add export routes in backend for reports and flashcard sets
- implement corresponding download handlers on content cards
- expose helpers in storage for fetching single report and flashcard set
- fix type definition for `FlashcardSetCard` props

## Testing
- `npm run check` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68689bec44c8833290318e06f71545ab