### PR TITLE
Implement basic tagging API

### DIFF
--- a/client/src/components/organization/TagInput.tsx
+++ b/client/src/components/organization/TagInput.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import { useTags } from '@/hooks/useTags';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+interface TagInputProps {
+  onAdd?: (tagId: number) => void;
+}
+
+const TagInput: React.FC<TagInputProps> = ({ onAdd }) => {
+  const { createTag } = useTags();
+  const [name, setName] = useState('');
+
+  const handleAdd = async () => {
+    if (!name.trim()) return;
+    const tag = await createTag.mutateAsync({ name });
+    onAdd?.(tag.id);
+    setName('');
+  };
+
+  return (
+    <div className="flex items-center space-x-2">
+      <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="New tag" />
+      <Button onClick={handleAdd} disabled={createTag.isPending}>
+        Add
+      </Button>
+    </div>
+  );
+};
+
+export default TagInput;

--- a/client/src/hooks/useTags.ts
+++ b/client/src/hooks/useTags.ts
@@ -1,0 +1,13 @@
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/queryClient";
+import type { Tag, InsertTag } from "@shared/schema";
+
+export function useTags() {
+  const { data: tags } = useQuery<Tag[]>({ queryKey: ["/api/tags"] });
+
+  const createTag = useMutation((tag: Omit<InsertTag, "userId">) =>
+    apiRequest("POST", "/api/tags", tag).then((r) => r.json() as Promise<Tag>)
+  );
+
+  return { tags, createTag };
+}

--- a/server/routers/index.ts
+++ b/server/routers/index.ts
@@ -5,6 +5,7 @@ import videosRouter from './videos.router';
 import reportsRouter from './reports.router';
 import flashcardsRouter from './flashcards.router';
 import ideasRouter from './ideas.router';
+import tagsRouter from './tags.router';
 import devRouter from './dev.router';
 import { setupAuth } from '../replitAuth';
 import { errorHandler } from './middleware';
@@ -19,6 +20,7 @@ export async function registerAppRoutes(app: Express): Promise<Server> {
   app.use('/api/reports', reportsRouter);
   app.use('/api/flashcard-sets', flashcardsRouter);
   app.use('/api/idea-sets', ideasRouter);
+  app.use('/api/tags', tagsRouter);
   app.use('/api/dev', devRouter);
 
   // Apply global error handling middleware

--- a/server/routers/tags.router.ts
+++ b/server/routers/tags.router.ts
@@ -1,0 +1,76 @@
+import { Router } from 'express';
+import { isAuthenticated } from '../replitAuth';
+import { storage } from '../storage';
+import { insertTagSchema } from '@shared/schema';
+import { ZodError } from 'zod';
+
+const router = Router();
+
+router.get('/', isAuthenticated, async (req: any, res, next) => {
+  try {
+    const userId = req.user.claims.sub;
+    const tags = await storage.getUserTags(userId);
+    res.json(tags);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/', isAuthenticated, async (req: any, res, next) => {
+  try {
+    const userId = req.user.claims.sub;
+    const tag = insertTagSchema.parse({ ...req.body, userId });
+    const created = await storage.createTag(tag);
+    res.status(201).json(created);
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return res.status(400).json({ message: 'Invalid tag data', errors: err.errors });
+    }
+    next(err);
+  }
+});
+
+router.put('/:id', isAuthenticated, async (req: any, res, next) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const updated = await storage.updateTag(id, req.body);
+    if (!updated) return res.status(404).json({ message: 'Tag not found' });
+    res.json(updated);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/:id', isAuthenticated, async (req: any, res, next) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    await storage.deleteTag(id);
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/video/:videoId/:tagId', isAuthenticated, async (req: any, res, next) => {
+  try {
+    const videoId = parseInt(req.params.videoId, 10);
+    const tagId = parseInt(req.params.tagId, 10);
+    await storage.addTagToVideo(videoId, tagId);
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/video/:videoId/:tagId', isAuthenticated, async (req: any, res, next) => {
+  try {
+    const videoId = parseInt(req.params.videoId, 10);
+    const tagId = parseInt(req.params.tagId, 10);
+    await storage.removeTagFromVideo(videoId, tagId);
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -8,6 +8,7 @@ import {
   jsonb,
   varchar,
   index,
+  primaryKey,
 } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
@@ -160,6 +161,30 @@ export const ideaRelations = relations(ideas, ({ one }) => ({
   }),
 }));
 
+// Tags table
+export const tags = pgTable("tags", {
+  id: serial("id").primaryKey(),
+  userId: varchar("user_id").notNull().references(() => users.id),
+  name: varchar("name", { length: 50 }).notNull(),
+  color: varchar("color", { length: 7 }),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
+export const videoTags = pgTable(
+  "video_tags",
+  {
+    videoId: integer("video_id")
+      .notNull()
+      .references(() => videos.id, { onDelete: "cascade" }),
+    tagId: integer("tag_id")
+      .notNull()
+      .references(() => tags.id, { onDelete: "cascade" }),
+  },
+  (t) => ({
+    pk: primaryKey(t.videoId, t.tagId),
+  })
+);
+
 // Insert schemas for all tables
 export const insertVideoSchema = createInsertSchema(videos).omit({ id: true, createdAt: true });
 export const insertSummarySchema = createInsertSchema(summaries).omit({ id: true, createdAt: true });
@@ -168,6 +193,7 @@ export const insertFlashcardSetSchema = createInsertSchema(flashcardSets).omit({
 export const insertFlashcardSchema = createInsertSchema(flashcards).omit({ id: true, createdAt: true });
 export const insertIdeaSetSchema = createInsertSchema(ideaSets).omit({ id: true, createdAt: true });
 export const insertIdeaSchema = createInsertSchema(ideas).omit({ id: true, createdAt: true });
+export const insertTagSchema = createInsertSchema(tags).omit({ id: true, createdAt: true });
 
 // Export types
 export type InsertVideo = z.infer<typeof insertVideoSchema>;
@@ -177,6 +203,7 @@ export type InsertFlashcardSet = z.infer<typeof insertFlashcardSetSchema>;
 export type InsertFlashcard = z.infer<typeof insertFlashcardSchema>;
 export type InsertIdeaSet = z.infer<typeof insertIdeaSetSchema>;
 export type InsertIdea = z.infer<typeof insertIdeaSchema>;
+export type InsertTag = z.infer<typeof insertTagSchema>;
 
 export type Video = typeof videos.$inferSelect;
 export type Summary = typeof summaries.$inferSelect;
@@ -185,6 +212,7 @@ export type FlashcardSet = typeof flashcardSets.$inferSelect;
 export type Flashcard = typeof flashcards.$inferSelect;
 export type IdeaSet = typeof ideaSets.$inferSelect;
 export type Idea = typeof ideas.$inferSelect;
+export type Tag = typeof tags.$inferSelect;
 
 // YouTube URL validation schema
 export const youtubeUrlSchema = z.object({


### PR DESCRIPTION
## Summary
- add tag and video_tag tables
- expose CRUD endpoints for tags
- support assigning tags to videos
- add simple React hook and input component for tags

## Testing
- `npm run check` *(fails: missing type definitions and ts errors)*
- `npm run db:push` *(fails: DATABASE_URL missing)*

------
https://chatgpt.com/codex/tasks/task_e_68689c00256883329a29d9e1b5ff23b8