### PR TITLE
Implement basic settings page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,13 +6,16 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import NotFound from "@/pages/not-found";
 import Dashboard from "@/pages/dashboard";
 import VideoDetail from "@/pages/video-detail";
+import SettingsPage from "@/pages/settings";
 import AppLayout from "@/components/layout/AppLayout";
+import { SettingsProvider } from "@/contexts/SettingsContext";
 
 function Router() {
   return (
     <Switch>
       <Route path="/" component={Dashboard} />
       <Route path="/videos/:id" component={VideoDetail} />
+      <Route path="/settings" component={SettingsPage} />
       {/* Fallback to 404 */}
       <Route component={NotFound} />
     </Switch>
@@ -23,9 +26,11 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
-        <AppLayout>
-          <Router />
-        </AppLayout>
+        <SettingsProvider>
+          <AppLayout>
+            <Router />
+          </AppLayout>
+        </SettingsProvider>
         <Toaster />
       </TooltipProvider>
     </QueryClientProvider>

--- a/client/src/components/layout/AppLayout.tsx
+++ b/client/src/components/layout/AppLayout.tsx
@@ -5,6 +5,7 @@ import MobileNav from "./MobileNav";
 import MobileMenu from "./MobileMenu";
 import { Button } from "@/components/ui/button";
 import { useLocation } from "wouter";
+import { useTheme } from "@/hooks/useTheme";
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -14,6 +15,7 @@ const AppLayout = ({ children }: AppLayoutProps) => {
   const { user, isLoading, isAuthenticated } = useAuth();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [, navigate] = useLocation();
+  useTheme();
 
   const toggleMobileMenu = () => {
     setIsMobileMenuOpen(!isMobileMenuOpen);

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -16,6 +16,7 @@ const Sidebar = ({ user }: SidebarProps) => {
     { icon: "description", label: "My Reports", path: "/reports" },
     { icon: "style", label: "My Flashcards", path: "/flashcards" },
     { icon: "lightbulb", label: "Ideas", path: "/ideas" },
+    { icon: "settings", label: "Settings", path: "/settings" },
   ];
 
   return (

--- a/client/src/components/settings/ThemeSelector.tsx
+++ b/client/src/components/settings/ThemeSelector.tsx
@@ -1,0 +1,22 @@
+import { useTheme } from "@/hooks/useTheme";
+
+const ThemeSelector = () => {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-lg font-medium">Theme</h2>
+      <select
+        value={theme}
+        onChange={(e) => setTheme(e.target.value as any)}
+        className="border rounded p-2"
+      >
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+        <option value="system">System</option>
+      </select>
+    </div>
+  );
+};
+
+export default ThemeSelector;

--- a/client/src/contexts/SettingsContext.tsx
+++ b/client/src/contexts/SettingsContext.tsx
@@ -1,0 +1,45 @@
+import { createContext, useEffect, useState } from "react";
+
+export type Theme = "light" | "dark" | "system";
+
+export interface UserSettings {
+  theme: Theme;
+}
+
+interface SettingsContextValue {
+  settings: UserSettings;
+  updateSettings: (updates: Partial<UserSettings>) => void;
+}
+
+export const SettingsContext = createContext<SettingsContextValue | null>(null);
+
+export const SettingsProvider = ({ children }: { children: React.ReactNode }) => {
+  const [settings, setSettings] = useState<UserSettings>(() => {
+    const saved = localStorage.getItem("userSettings");
+    return saved ? JSON.parse(saved) : { theme: "system" };
+  });
+
+  useEffect(() => {
+    localStorage.setItem("userSettings", JSON.stringify(settings));
+  }, [settings]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (settings.theme === "system") {
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      root.classList.toggle("dark", prefersDark);
+    } else {
+      root.classList.toggle("dark", settings.theme === "dark");
+    }
+  }, [settings.theme]);
+
+  const updateSettings = (updates: Partial<UserSettings>) => {
+    setSettings((prev) => ({ ...prev, ...updates }));
+  };
+
+  return (
+    <SettingsContext.Provider value={{ settings, updateSettings }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};

--- a/client/src/hooks/useSettings.ts
+++ b/client/src/hooks/useSettings.ts
@@ -1,0 +1,8 @@
+import { useContext } from "react";
+import { SettingsContext } from "@/contexts/SettingsContext";
+
+export function useSettings() {
+  const ctx = useContext(SettingsContext);
+  if (!ctx) throw new Error("SettingsProvider is missing");
+  return ctx;
+}

--- a/client/src/hooks/useTheme.ts
+++ b/client/src/hooks/useTheme.ts
@@ -1,0 +1,12 @@
+import { useSettings } from "./useSettings";
+import { Theme } from "@/contexts/SettingsContext";
+
+export function useTheme() {
+  const { settings, updateSettings } = useSettings();
+
+  const setTheme = (theme: Theme) => {
+    updateSettings({ theme });
+  };
+
+  return { theme: settings.theme, setTheme };
+}

--- a/client/src/pages/settings/index.tsx
+++ b/client/src/pages/settings/index.tsx
@@ -1,0 +1,12 @@
+import ThemeSelector from "@/components/settings/ThemeSelector";
+
+const SettingsPage = () => {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-semibold mb-4">Settings</h1>
+      <ThemeSelector />
+    </main>
+  );
+};
+
+export default SettingsPage;


### PR DESCRIPTION
## Summary
- add `SettingsProvider` and context for theme preference
- implement `useTheme` and `useSettings` hooks
- add theme selector component and settings page
- register settings route and sidebar link

## Testing
- `npm run check` *(fails: numerous TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68689c0739708332a1f166bb961dd674